### PR TITLE
fix for attempts to show debuginfo of nonexistant mobs

### DIFF
--- a/mobf/debug.lua
+++ b/mobf/debug.lua
@@ -378,6 +378,10 @@ end
 ------------------------------------------------------------------------------
 function mobf_debug.rightclick_callback(entity,player)
 	local basepos  = entity.getbasepos(entity)
+	if (nil == basepos) then
+		print("MOBF: \tCould not determine position")
+		return false
+	end
 	local lifetime = mobf_get_current_time() - entity.dynamic_data.spawning.original_spawntime
 	print("MOBF: " .. entity.data.name .. " " .. tostring(entity) .. " is alive for " .. lifetime .. " seconds")
 	print("MOBF: \tAbsolute spawntime:          " .. entity.dynamic_data.spawning.original_spawntime)

--- a/mobf/mobf.lua
+++ b/mobf/mobf.lua
@@ -256,6 +256,9 @@ end
 -------------------------------------------------------------------------------
 function mobf.get_basepos(entity)
 	local pos = entity.object:getpos()
+	if (nil == pos) then
+		return pos
+	end
 	local nodeatpos = minetest.get_node(pos)
 
 	dbg_mobf.mobf_core_helper_lvl3("MOBF: " .. entity.data.name


### PR DESCRIPTION
The minetest server can crash when doing a right-click on a MOB, and having the MOB disappear somehow before clicking "show debug info". It is fixed on this branch by checking for invalid positions.