### PR TITLE
Replace deprecated function 'intllib.Getter'

### DIFF
--- a/barn/init.lua
+++ b/barn/init.lua
@@ -16,7 +16,7 @@
 
 -- Boilerplate to support localized strings if intllib mod is installed.
 local S
-if (minetest.get_modpath("intllib")) then
+if (minetest.global_exists("intllib")) then
   dofile(minetest.get_modpath("intllib").."/intllib.lua")
   S = intllib.Getter(minetest.get_current_modname())
 else

--- a/barn/init.lua
+++ b/barn/init.lua
@@ -18,7 +18,11 @@
 local S
 if (minetest.global_exists("intllib")) then
   dofile(minetest.get_modpath("intllib").."/intllib.lua")
-  S = intllib.Getter(minetest.get_current_modname())
+  if intllib.make_gettext_pair then
+    S = intllib.make_gettext_pair(minetest.get_current_modname())
+  else
+    S = intllib.Getter(minetest.get_current_modname())
+  end
 else
   S = function ( s ) return s end
 end

--- a/mobf/inventory.lua
+++ b/mobf/inventory.lua
@@ -27,7 +27,11 @@ mob_inventory = {}
 -- Boilerplate to support localized strings if intllib mod is installed.
 local S
 if core.global_exists("intllib") then
-	S = intllib.Getter()
+	if intllib.make_gettext_pair then
+		S = intllib.make_gettext_pair()
+	else
+		S = intllib.Getter()
+	end
 else
 	S = function(s) return s end
 end

--- a/mobf/path.lua
+++ b/mobf/path.lua
@@ -15,7 +15,7 @@
 
 -- Boilerplate to support localized strings if intllib mod is installed.
 local S
-if (minetest.get_modpath("intllib")) then
+if (minetest.global_exists("intllib")) then
   dofile(minetest.get_modpath("intllib").."/intllib.lua")
   S = intllib.Getter(minetest.get_current_modname())
 else

--- a/mobf/path.lua
+++ b/mobf/path.lua
@@ -17,7 +17,11 @@
 local S
 if (minetest.global_exists("intllib")) then
   dofile(minetest.get_modpath("intllib").."/intllib.lua")
-  S = intllib.Getter(minetest.get_current_modname())
+  if intllib.make_gettext_pair then
+    S = intllib.make_gettext_pair(minetest.get_current_modname())
+  else
+    S = intllib.Getter(minetest.get_current_modname())
+  end
 else
   S = function ( s ) return s end
 end

--- a/trap/init.lua
+++ b/trap/init.lua
@@ -1,6 +1,6 @@
 -- Boilerplate to support localized strings if intllib mod is installed.
 local S
-if (minetest.get_modpath("intllib")) then
+if (minetest.global_exists("intllib")) then
   dofile(minetest.get_modpath("intllib").."/intllib.lua")
   S = intllib.Getter(minetest.get_current_modname())
 else

--- a/trap/init.lua
+++ b/trap/init.lua
@@ -2,7 +2,11 @@
 local S
 if (minetest.global_exists("intllib")) then
   dofile(minetest.get_modpath("intllib").."/intllib.lua")
-  S = intllib.Getter(minetest.get_current_modname())
+  if intllib.make_gettext_pair then
+    S = intllib.make_gettext_pair(minetest.get_current_modname())
+  else
+    S = intllib.Getter(minetest.get_current_modname())
+  end
 else
   S = function ( s ) return s end
 end


### PR DESCRIPTION
- Check first for *intllib.make_gettext_pair*, otherwise continue using
deprecated function *intllib.Getter*.
- Call *minetest.global_exists* in place of *minetest.get_modpath* (Better practice for mod testing in my opinion)